### PR TITLE
Fix callback type cast error with noexcept

### DIFF
--- a/dubins/core.pxd
+++ b/dubins/core.pxd
@@ -28,8 +28,8 @@ cdef extern from "dubins.h":
         pass
 
     # The c-version of the initialisation function 
-    cdef int dubins_shortest_path(DubinsPath* path, double q0[3], double q1[3], double rho);
-    cdef int dubins_path(DubinsPath* path, double q0[3], double q1[3], double rho, int pathType);
+    cdef int dubins_shortest_path(DubinsPath* path, double q0[3], double q1[3], double rho)
+    cdef int dubins_path(DubinsPath* path, double q0[3], double q1[3], double rho, int pathType)
     
     # Enough "glue code to make sure that the path can be sampled
     ctypedef int (*DubinsPathSamplingCallback)(double q[3], double t, void* user_data)
@@ -42,5 +42,5 @@ cdef extern from "dubins.h":
     cdef double dubins_segment_length(DubinsPath* path, int i)
     cdef double dubins_segment_length_normalized(DubinsPath* path, int i)
     cdef int dubins_path_endpoint(DubinsPath* path, double q[3])
-    cdef int dubins_extract_subpath(DubinsPath* path, double t, DubinsPath* newpath);
+    cdef int dubins_extract_subpath(DubinsPath* path, double t, DubinsPath* newpath)
 

--- a/dubins/dubins.pyx
+++ b/dubins/dubins.pyx
@@ -22,7 +22,7 @@ cimport core
 from libc.stdlib cimport malloc, free
 
 
-cdef inline int callback(double q[3], double t, void* f):
+cdef inline int callback(double q[3], double t, void* f) noexcept:
     '''Internal c-callback to convert values back to python
     '''
     qn = (q[0], q[1], q[2])

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read(filename):
 
 setup(
     name         = "dubins",
-    version      = "1.1.0",
+    version      = "1.1.1",
     description  = "Code to generate and manipulate dubins curves",
     long_description = read('README.rst'),
     author       = "Andrew Walker",


### PR DESCRIPTION
## Problem Description
`dubins` package install failure.

Original error is `dubins/dubins.pyx:123:59: Cannot assign type 'int (double *, double, void *) except? -1' to 'DubinsPathSamplingCallback'`

Full build error:

```
× Getting requirements to build wheel did not run successfully.
       →   │ exit code: 1
       →   ╰─> [37 lines of output]
       →       /tmp/pip-build-env-oa1s7mr_/overlay/lib/python3.9/site-packages/Cython/Compiler/Main.py:381: FutureWarning: Cython directive 'language_level' not set, using '3str' for now (Py3). This has changed from earlier releases! File: /tmp/pip-install-39x6p0iw/dubins_bd392c44bca54945acbc3bc22c278c3d/dubins/dubins.pyx
       →         tree = Parsing.p_module(s, pxd, full_module_name)
       →       
       →       Error compiling Cython file:
       →       ------------------------------------------------------------
       →       ...
       →               ts = []
       →               def f(q, t):
       →                   qs.append(q)
       →                   ts.append(t)
       →                   return 0
       →               core.dubins_path_sample_many(self.ppth, step_size, callback, <void*>f)
       →                                                                  ^
       →       ------------------------------------------------------------
       →       
       →       dubins/dubins.pyx:123:59: Cannot assign type 'int (double *, double, void *) except? -1' to 'DubinsPathSamplingCallback'
       →       Compiling dubins/dubins.pyx because it changed.
       →       [1/1] Cythonizing dubins/dubins.pyx
       →       Traceback (most recent call last):
       →         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
       →           main()
       →         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
       →           json_out['return_val'] = hook(**hook_input['kwargs'])
       →         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
       →           return hook(config_settings)
       →         File "/tmp/pip-build-env-oa1s7mr_/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
       →           return self._get_build_requires(config_settings, requirements=['wheel'])
       →         File "/tmp/pip-build-env-oa1s7mr_/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
       →           self.run_setup()
       →         File "/tmp/pip-build-env-oa1s7mr_/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 338, in run_setup
       →           exec(code, locals())
       →         File "<string>", line 42, in <module>
       →         File "/tmp/pip-build-env-oa1s7mr_/overlay/lib/python3.9/site-packages/Cython/Build/Dependencies.py", line 1134, in cythonize
       →           cythonize_one(*args)
       →         File "/tmp/pip-build-env-oa1s7mr_/overlay/lib/python3.9/site-packages/Cython/Build/Dependencies.py", line 1301, in cythonize_one
       →           raise CompileError(None, pyx_file)
       →       Cython.Compiler.Errors.CompileError: dubins/dubins.pyx
       →       [end of output]
       →   
       →   note: This error originates from a subprocess, and is likely not a problem with pip.
       → error: subprocess-exited-with-error
       → 
       → × Getting requirements to build wheel did not run successfully.
       → │ exit code: 1
       → ╰─> See above for output.
       → 
       → note: This error originates from a subprocess, and is likely not a problem with pip.
```

## Proposed Fix

Add `noexcept` to callback definition to prevent `except? -1` being inferred.